### PR TITLE
Expose weather-based precipitation skip as switch + number entities

### DIFF
--- a/custom_components/smart_irrigation/__init__.py
+++ b/custom_components/smart_irrigation/__init__.py
@@ -292,7 +292,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
 
     _LOGGER.info("Calling async_forward_entry_setups")
     await hass.config_entries.async_forward_entry_setups(
-        entry, [PLATFORM, "number", "button", "binary_sensor"]
+        entry, [PLATFORM, "number", "button", "binary_sensor", "switch"]
     )
     _LOGGER.info("Finished calling async_forward_entry_setups")
 
@@ -372,6 +372,7 @@ async def async_unload_entry(hass: HomeAssistant, entry):
             hass.config_entries.async_forward_entry_unload(entry, "number"),
             hass.config_entries.async_forward_entry_unload(entry, "button"),
             hass.config_entries.async_forward_entry_unload(entry, "binary_sensor"),
+            hass.config_entries.async_forward_entry_unload(entry, "switch"),
         )
     )
     if not unload_ok:

--- a/custom_components/smart_irrigation/number.py
+++ b/custom_components/smart_irrigation/number.py
@@ -1,8 +1,13 @@
-"""Number platform for Smart Irrigation: the per-zone irrigation multiplier.
+"""Number platform for Smart Irrigation: multiplier and precipitation threshold.
 
-Exposes each zone's multiplier as an editable number under the zone device.
-Setting it writes straight to the zone store (used by the next calculation),
-mirroring the panel's multiplier field.
+Per zone (on the zone device):
+- multiplier: editable irrigation multiplier, mirroring the panel's field.
+  Setting it writes straight to the zone store (used by the next calculation).
+
+Global (on the hub device):
+- precipitation_threshold: the panel's "Precipitation Threshold (mm)" setting,
+  paired with the "skip_on_precipitation" switch (see switch.py). Writes go
+  through ``coordinator.async_update_config``, same as the panel.
 
 Per-zone entity approach inspired by JustChr's Smart Irrigation fork (MIT).
 """
@@ -11,7 +16,11 @@ import contextlib
 import logging
 
 from homeassistant.components.number import DOMAIN as NUMBER_PLATFORM
-from homeassistant.components.number import NumberEntity, NumberMode
+from homeassistant.components.number import (
+    NumberDeviceClass,
+    NumberEntity,
+    NumberMode,
+)
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.dispatcher import (
@@ -21,11 +30,21 @@ from homeassistant.helpers.dispatcher import (
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.restore_state import RestoreEntity
 from homeassistant.util import slugify
+from homeassistant.util.unit_system import METRIC_SYSTEM
 
 from . import const
-from .entity import zone_device_info
+from .entity import hub_device_info, zone_device_info
+from .helpers import convert_between
 
 _LOGGER = logging.getLogger(__name__)
+
+
+def _coordinator(hass: HomeAssistant):
+    """Return the coordinator, or None when not (yet) set up."""
+    try:
+        return hass.data[const.DOMAIN]["coordinator"]
+    except (KeyError, AttributeError):
+        return None
 
 
 async def async_setup_entry(
@@ -62,6 +81,9 @@ async def async_setup_entry(
             hass, const.DOMAIN + "_register_entity", async_add_number_entity
         )
     )
+
+    # Global (hub-device) precipitation threshold, created once.
+    async_add_devices([SmartIrrigationPrecipitationThresholdNumber(hass)])
 
 
 class SmartIrrigationZoneMultiplierEntity(NumberEntity, RestoreEntity):
@@ -154,3 +176,120 @@ class SmartIrrigationZoneMultiplierEntity(NumberEntity, RestoreEntity):
             with contextlib.suppress(ValueError, TypeError):
                 self._multiplier = float(last_state.state)
         self.async_schedule_update_ha_state(force_refresh=True)
+
+
+class SmartIrrigationPrecipitationThresholdNumber(NumberEntity):
+    """Editable "Precipitation Threshold (mm)" setting, on the hub device.
+
+    Paired with the "skip_on_precipitation" switch (switch.py): irrigation is
+    skipped when forecast precipitation meets or exceeds this threshold.
+
+    The store always keeps this value in mm, but ``coordinator.async_update_config``
+    interprets an incoming value as inches when HA is configured for imperial units
+    (mirroring what the panel sends -- a raw number in the user's current unit
+    system). So this entity's native unit tracks ``hass.config.units`` and passes
+    the raw displayed value straight through, rather than always converting to mm.
+    """
+
+    _attr_has_entity_name = True
+    _attr_should_poll = False
+    _attr_translation_key = "precipitation_threshold"
+    _attr_device_class = NumberDeviceClass.PRECIPITATION
+    _attr_mode = NumberMode.BOX
+    _attr_icon = "mdi:weather-pouring"
+    _attr_native_min_value = 0.0
+
+    def __init__(self, hass: HomeAssistant) -> None:
+        """Initialize the precipitation threshold number."""
+        self._hass = hass
+        self.entity_id = f"{NUMBER_PLATFORM}.{const.DOMAIN}_precipitation_threshold"
+        self._threshold_mm = const.CONF_DEFAULT_PRECIPITATION_THRESHOLD_MM
+
+    def _is_metric(self) -> bool:
+        """Return whether HA is configured for the metric system."""
+        return self._hass.config.units is METRIC_SYSTEM
+
+    @property
+    def unique_id(self) -> str:
+        """Return a stable unique ID."""
+        return f"{const.DOMAIN}_precipitation_threshold"
+
+    @property
+    def device_info(self) -> dict:
+        """Group under the hub device."""
+        return hub_device_info(self._hass)
+
+    @property
+    def should_poll(self) -> bool:
+        """No polling; updated via dispatcher."""
+        return False
+
+    @property
+    def native_unit_of_measurement(self) -> str:
+        """Match HA's current unit system (mm or inches)."""
+        return const.UNIT_MM if self._is_metric() else const.UNIT_INCH
+
+    @property
+    def native_max_value(self) -> float:
+        """Return the upper bound, in the current display unit (~50 mm)."""
+        return 50.0 if self._is_metric() else 2.0
+
+    @property
+    def native_step(self) -> float:
+        """Return the step size, in the current display unit (~0.5 mm)."""
+        return 0.5 if self._is_metric() else 0.05
+
+    @property
+    def native_value(self) -> float:
+        """Return the threshold, converted to the current display unit."""
+        if self._is_metric():
+            return round(self._threshold_mm, 2)
+        return round(
+            convert_between(const.UNIT_MM, const.UNIT_INCH, self._threshold_mm), 3
+        )
+
+    async def async_set_native_value(self, value: float) -> None:
+        """Persist a new threshold and notify entities and any open panel."""
+        coordinator = _coordinator(self._hass)
+        if coordinator is None:
+            return
+        # Mirrors the panel: send the raw value in the current display unit;
+        # the coordinator itself converts inches -> mm when HA is not metric.
+        await coordinator.async_update_config(
+            {const.CONF_PRECIPITATION_THRESHOLD_MM: value}
+        )
+        self._recompute()
+        self.async_write_ha_state()
+        async_dispatcher_send(self._hass, const.DOMAIN + "_update_frontend")
+
+    async def async_added_to_hass(self) -> None:
+        """Subscribe to config updates and read the initial state."""
+        await super().async_added_to_hass()
+        self.async_on_remove(
+            async_dispatcher_connect(
+                self._hass, const.DOMAIN + "_config_updated", self._async_refresh
+            )
+        )
+        self._recompute()
+
+    @callback
+    def _async_refresh(self, zone_id=None) -> None:
+        """Refresh when the global config changes (e.g. edited from the panel).
+
+        ``_config_updated`` is also sent (with a zone_id) for per-zone changes,
+        which don't affect this global setting; skip those.
+        """
+        if zone_id is not None:
+            return
+        self._recompute()
+        self.async_write_ha_state()
+
+    @callback
+    def _recompute(self) -> None:
+        """Read the current mm value from the store."""
+        coordinator = _coordinator(self._hass)
+        config = coordinator.store.get_config() if coordinator else {}
+        self._threshold_mm = config.get(
+            const.CONF_PRECIPITATION_THRESHOLD_MM,
+            const.CONF_DEFAULT_PRECIPITATION_THRESHOLD_MM,
+        )

--- a/custom_components/smart_irrigation/switch.py
+++ b/custom_components/smart_irrigation/switch.py
@@ -1,0 +1,123 @@
+"""Switch platform for Smart Irrigation: the global weather-based skip toggle.
+
+Exposes the panel's "Weather-based Irrigation Skip" setting as a switch on
+the hub device, so it can be controlled from automations and dashboards, not
+just the panel. Writes go through the coordinator's regular config path
+(``coordinator.async_update_config``), so the panel and any other listening
+entities (e.g. a future skip-reason sensor) pick up the change immediately,
+and vice versa: toggling it in the panel refreshes this switch too.
+"""
+
+import logging
+
+from homeassistant.components.switch import DOMAIN as SWITCH_PLATFORM
+from homeassistant.components.switch import SwitchEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.dispatcher import (
+    async_dispatcher_connect,
+    async_dispatcher_send,
+)
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from . import const
+from .entity import hub_device_info
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def _coordinator(hass: HomeAssistant):
+    """Return the coordinator, or None when not (yet) set up."""
+    try:
+        return hass.data[const.DOMAIN]["coordinator"]
+    except (KeyError, AttributeError):
+        return None
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_devices: AddEntitiesCallback,
+) -> None:
+    """Set up the global weather-based skip switch (created once, on the hub)."""
+    async_add_devices([SmartIrrigationSkipOnPrecipitationSwitch(hass)])
+
+
+class SmartIrrigationSkipOnPrecipitationSwitch(SwitchEntity):
+    """Toggle the panel's "Weather-based Irrigation Skip" setting."""
+
+    _attr_has_entity_name = True
+    _attr_should_poll = False
+    _attr_translation_key = "skip_on_precipitation"
+    _attr_icon = "mdi:weather-pouring"
+
+    def __init__(self, hass: HomeAssistant) -> None:
+        """Initialize the switch."""
+        self._hass = hass
+        self.entity_id = f"{SWITCH_PLATFORM}.{const.DOMAIN}_skip_on_precipitation"
+
+    @property
+    def unique_id(self) -> str:
+        """Return a stable unique ID."""
+        return f"{const.DOMAIN}_skip_irrigation_on_precipitation"
+
+    @property
+    def device_info(self) -> dict:
+        """Group under the hub device."""
+        return hub_device_info(self._hass)
+
+    async def async_added_to_hass(self) -> None:
+        """Subscribe to config updates and read the initial state."""
+        await super().async_added_to_hass()
+        self.async_on_remove(
+            async_dispatcher_connect(
+                self._hass, const.DOMAIN + "_config_updated", self._async_refresh
+            )
+        )
+        self._recompute()
+
+    @callback
+    def _async_refresh(self, zone_id=None) -> None:
+        """Refresh when the global config changes (e.g. edited from the panel).
+
+        ``_config_updated`` is also sent (with a zone_id) for per-zone changes,
+        which don't affect this global setting; skip those.
+        """
+        if zone_id is not None:
+            return
+        self._recompute()
+        self.async_write_ha_state()
+
+    @callback
+    def _recompute(self) -> None:
+        """Read the current value from the store."""
+        coordinator = _coordinator(self._hass)
+        config = coordinator.store.get_config() if coordinator else {}
+        self._attr_is_on = config.get(
+            const.CONF_SKIP_IRRIGATION_ON_PRECIPITATION,
+            const.CONF_DEFAULT_SKIP_IRRIGATION_ON_PRECIPITATION,
+        )
+
+    async def async_turn_on(self, **kwargs) -> None:
+        """Enable the weather-based skip."""
+        await self._async_set(True)
+
+    async def async_turn_off(self, **kwargs) -> None:
+        """Disable the weather-based skip."""
+        await self._async_set(False)
+
+    async def _async_set(self, value: bool) -> None:
+        """Persist the toggle and notify entities and any open panel."""
+        coordinator = _coordinator(self._hass)
+        if coordinator is None:
+            return
+        await coordinator.async_update_config(
+            {const.CONF_SKIP_IRRIGATION_ON_PRECIPITATION: value}
+        )
+        self._attr_is_on = value
+        self.async_write_ha_state()
+        # coordinator.async_update_config() already sent "_config_updated" for
+        # other entities; the panel listens for "_update_frontend" instead
+        # (see websockets.py's SmartIrrigationConfigView.post for the same
+        # pairing), so send that too to keep an open panel in sync.
+        async_dispatcher_send(self._hass, const.DOMAIN + "_update_frontend")

--- a/custom_components/smart_irrigation/translations/en.json
+++ b/custom_components/smart_irrigation/translations/en.json
@@ -26,6 +26,9 @@
     "number": {
       "multiplier": {
         "name": "Multiplier"
+      },
+      "precipitation_threshold": {
+        "name": "Precipitation threshold"
       }
     },
     "button": {
@@ -60,6 +63,11 @@
       },
       "problem": {
         "name": "Problem"
+      }
+    },
+    "switch": {
+      "skip_on_precipitation": {
+        "name": "Skip on precipitation"
       }
     }
   },

--- a/tests/test_number.py
+++ b/tests/test_number.py
@@ -1,0 +1,134 @@
+"""Test the Smart Irrigation number platform's global precipitation threshold.
+
+The per-zone multiplier entity (SmartIrrigationZoneMultiplierEntity) has no
+existing test coverage to extend; these tests cover the new
+SmartIrrigationPrecipitationThresholdNumber hub entity only.
+"""
+
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+from homeassistant.util.unit_system import METRIC_SYSTEM, US_CUSTOMARY_SYSTEM
+
+from custom_components.smart_irrigation import const
+from custom_components.smart_irrigation.number import (
+    SmartIrrigationPrecipitationThresholdNumber,
+)
+
+
+def _hass_with_config(config: dict, units=METRIC_SYSTEM):
+    """Return a minimal hass double wired to a coordinator/store returning config."""
+    hass = Mock()
+    hass.data = {}
+    hass.config = Mock()
+    hass.config.units = units
+    store = Mock()
+    store.get_config = Mock(return_value=dict(config))
+    coordinator = Mock()
+    coordinator.store = store
+    coordinator.async_update_config = AsyncMock()
+    hass.data[const.DOMAIN] = {"coordinator": coordinator}
+    return hass, coordinator
+
+
+@pytest.fixture
+def number_entity():
+    """Return a number entity (metric) wired to a hass double."""
+    hass, coordinator = _hass_with_config(
+        {const.CONF_PRECIPITATION_THRESHOLD_MM: 3.0}, units=METRIC_SYSTEM
+    )
+    entity = SmartIrrigationPrecipitationThresholdNumber(hass)
+    entity.hass = hass
+    entity.async_write_ha_state = Mock()
+    return entity, coordinator
+
+
+def test_unique_id_and_entity_id():
+    """The number has a stable, hub-scoped unique_id and entity_id."""
+    hass, _ = _hass_with_config({})
+    entity = SmartIrrigationPrecipitationThresholdNumber(hass)
+    assert entity.unique_id == f"{const.DOMAIN}_precipitation_threshold"
+    assert entity.entity_id == f"number.{const.DOMAIN}_precipitation_threshold"
+
+
+async def test_initial_state_reflects_store_metric(number_entity):
+    """In a metric HA instance, the value and unit are mm, unconverted."""
+    entity, _coordinator = number_entity
+    await entity.async_added_to_hass()
+    assert entity.native_value == 3.0
+    assert entity.native_unit_of_measurement == const.UNIT_MM
+
+
+async def test_initial_state_defaults_when_missing():
+    """Falls back to the integration default when the config key is absent."""
+    hass, _coordinator = _hass_with_config({}, units=METRIC_SYSTEM)
+    entity = SmartIrrigationPrecipitationThresholdNumber(hass)
+    entity.hass = hass
+    entity.async_write_ha_state = Mock()
+    await entity.async_added_to_hass()
+    assert entity.native_value == const.CONF_DEFAULT_PRECIPITATION_THRESHOLD_MM
+
+
+async def test_imperial_instance_displays_inches():
+    """In an imperial HA instance, the mm store value displays as inches."""
+    hass, _coordinator = _hass_with_config(
+        {const.CONF_PRECIPITATION_THRESHOLD_MM: 25.4}, units=US_CUSTOMARY_SYSTEM
+    )
+    entity = SmartIrrigationPrecipitationThresholdNumber(hass)
+    entity.hass = hass
+    entity.async_write_ha_state = Mock()
+    await entity.async_added_to_hass()
+    assert entity.native_unit_of_measurement == const.UNIT_INCH
+    assert entity.native_value == pytest.approx(1.0, abs=0.01)
+
+
+async def test_set_native_value_metric_passes_value_through(number_entity):
+    """On a metric instance, the raw mm value is sent straight to the coordinator."""
+    entity, coordinator = number_entity
+    await entity.async_set_native_value(5.5)
+    coordinator.async_update_config.assert_awaited_once_with(
+        {const.CONF_PRECIPITATION_THRESHOLD_MM: 5.5}
+    )
+
+
+async def test_set_native_value_imperial_sends_raw_display_value():
+    """On an imperial instance, the raw (inch) value is sent, not pre-converted.
+
+    The coordinator's own async_update_config() applies the inches -> mm
+    conversion when HA is non-metric (see __init__.py), so this entity must not
+    convert twice.
+    """
+    hass, coordinator = _hass_with_config(
+        {const.CONF_PRECIPITATION_THRESHOLD_MM: 25.4}, units=US_CUSTOMARY_SYSTEM
+    )
+    entity = SmartIrrigationPrecipitationThresholdNumber(hass)
+    entity.hass = hass
+    entity.async_write_ha_state = Mock()
+    await entity.async_set_native_value(2.0)
+    coordinator.async_update_config.assert_awaited_once_with(
+        {const.CONF_PRECIPITATION_THRESHOLD_MM: 2.0}
+    )
+
+
+async def test_global_config_update_refreshes_entity(number_entity):
+    """A global "_config_updated" dispatch (zone_id=None) re-reads the store."""
+    entity, coordinator = number_entity
+    coordinator.store.get_config = Mock(
+        return_value={const.CONF_PRECIPITATION_THRESHOLD_MM: 9.0}
+    )
+    entity._async_refresh(zone_id=None)
+    assert entity.native_value == 9.0
+    entity.async_write_ha_state.assert_called()
+
+
+async def test_zone_scoped_config_update_is_ignored(number_entity):
+    """A per-zone "_config_updated" dispatch doesn't touch this global number."""
+    entity, coordinator = number_entity
+    entity._threshold_mm = 3.0
+    coordinator.store.get_config = Mock(
+        return_value={const.CONF_PRECIPITATION_THRESHOLD_MM: 9.0}
+    )
+    entity.async_write_ha_state.reset_mock()
+    entity._async_refresh(zone_id=42)
+    assert entity.native_value == 3.0
+    entity.async_write_ha_state.assert_not_called()

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -1,0 +1,105 @@
+"""Test the Smart Irrigation switch platform (global weather-based skip toggle)."""
+
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+from custom_components.smart_irrigation import const
+from custom_components.smart_irrigation.switch import (
+    SmartIrrigationSkipOnPrecipitationSwitch,
+)
+
+
+def _hass_with_config(config: dict):
+    """Return a minimal hass double wired to a coordinator/store returning config."""
+    hass = Mock()
+    hass.data = {}
+    store = Mock()
+    store.get_config = Mock(return_value=dict(config))
+    coordinator = Mock()
+    coordinator.store = store
+    coordinator.async_update_config = AsyncMock()
+    hass.data[const.DOMAIN] = {"coordinator": coordinator}
+    return hass, coordinator
+
+
+@pytest.fixture
+def switch_entity():
+    """Return a switch entity wired to a hass double, with state writes mocked."""
+    hass, coordinator = _hass_with_config(
+        {const.CONF_SKIP_IRRIGATION_ON_PRECIPITATION: False}
+    )
+    entity = SmartIrrigationSkipOnPrecipitationSwitch(hass)
+    entity.hass = hass
+    entity.async_write_ha_state = Mock()
+    return entity, coordinator
+
+
+def test_unique_id_and_entity_id():
+    """The switch has a stable, hub-scoped unique_id and entity_id."""
+    hass, _ = _hass_with_config({})
+    entity = SmartIrrigationSkipOnPrecipitationSwitch(hass)
+    assert entity.unique_id == f"{const.DOMAIN}_skip_irrigation_on_precipitation"
+    assert entity.entity_id == f"switch.{const.DOMAIN}_skip_on_precipitation"
+
+
+async def test_initial_state_reflects_store(switch_entity):
+    """async_added_to_hass reads the initial value from the store."""
+    entity, _coordinator = switch_entity
+    await entity.async_added_to_hass()
+    assert entity.is_on is False
+
+
+async def test_initial_state_defaults_when_missing():
+    """Falls back to the integration default when the config key is absent."""
+    hass, _coordinator = _hass_with_config({})
+    entity = SmartIrrigationSkipOnPrecipitationSwitch(hass)
+    entity.hass = hass
+    entity.async_write_ha_state = Mock()
+    await entity.async_added_to_hass()
+    assert entity.is_on == const.CONF_DEFAULT_SKIP_IRRIGATION_ON_PRECIPITATION
+
+
+async def test_turn_on_persists_via_coordinator(switch_entity):
+    """Turning on writes through coordinator.async_update_config and updates state."""
+    entity, coordinator = switch_entity
+    await entity.async_turn_on()
+    coordinator.async_update_config.assert_awaited_once_with(
+        {const.CONF_SKIP_IRRIGATION_ON_PRECIPITATION: True}
+    )
+    assert entity.is_on is True
+    entity.async_write_ha_state.assert_called()
+
+
+async def test_turn_off_persists_via_coordinator(switch_entity):
+    """Turning off writes through coordinator.async_update_config and updates state."""
+    entity, coordinator = switch_entity
+    await entity.async_turn_off()
+    coordinator.async_update_config.assert_awaited_once_with(
+        {const.CONF_SKIP_IRRIGATION_ON_PRECIPITATION: False}
+    )
+    assert entity.is_on is False
+
+
+async def test_global_config_update_refreshes_entity(switch_entity):
+    """A global "_config_updated" dispatch (zone_id=None) re-reads the store."""
+    entity, coordinator = switch_entity
+    coordinator.store.get_config = Mock(
+        return_value={const.CONF_SKIP_IRRIGATION_ON_PRECIPITATION: True}
+    )
+    entity._async_refresh(zone_id=None)
+    assert entity.is_on is True
+    entity.async_write_ha_state.assert_called()
+
+
+async def test_zone_scoped_config_update_is_ignored(switch_entity):
+    """A per-zone "_config_updated" dispatch doesn't touch this global switch."""
+    entity, coordinator = switch_entity
+    entity._attr_is_on = False
+    coordinator.store.get_config = Mock(
+        return_value={const.CONF_SKIP_IRRIGATION_ON_PRECIPITATION: True}
+    )
+    entity.async_write_ha_state.reset_mock()
+    entity._async_refresh(zone_id=42)
+    assert entity.is_on is False
+    entity.async_write_ha_state.assert_not_called()


### PR DESCRIPTION
## Motivation

The panel's **Weather-based Irrigation Skip** (Yes/No) and **Precipitation Threshold (mm)** settings (`skip_irrigation_on_precipitation`, `precipitation_threshold_mm` in `Config`) currently have no HA entity or service backing them. The only programmatic way to change them is the panel's own HTTP endpoint (`SmartIrrigationConfigView` / `/api/smart_irrigation/config`). That makes it impossible to drive this setting from an automation or a regular dashboard toggle/slider.

This PR adds two entities on the hub device:

| Entity | Config key | Effect |
|---|---|---|
| `switch.smart_irrigation_skip_on_precipitation` | `skip_irrigation_on_precipitation` | Enables/disables the forecast-precipitation skip (`skip_conditions.py`) |
| `number.smart_irrigation_precipitation_threshold` | `precipitation_threshold_mm` | The forecast threshold (mm) that triggers the skip |

## Design

- Both entities live on the existing hub device (`entity.hub_device_info`), following the same pattern as the existing hub-level buttons (`SmartIrrigationCalculateAllButton` etc. in `button.py`).
- Writes go through `coordinator.async_update_config()` — the exact same path the panel's HTTP view uses — so persistence and the `"_config_updated"` dispatcher signal come "for free." I also send `"_update_frontend"` after each write (mirroring `SmartIrrigationConfigView.post` and `observed_watering.py`), so an open panel session refreshes immediately too.
- Both subscribe to `"_config_updated"` and refresh from `store.get_config()` when it fires with `zone_id=None` (a global change); per-zone dispatches are ignored since they don't affect this global setting. This gives true bidirectional sync: panel → entity and entity → panel.
- **Unit handling**: the store always keeps the threshold in mm, but `coordinator.async_update_config()` interprets an incoming `precipitation_threshold_mm` value as *inches* when HA is configured for imperial units (see `__init__.py`), mirroring what the panel sends. So the number entity's `native_unit_of_measurement` tracks `hass.config.units` (mm or inches) and passes the raw displayed value straight through on write, rather than always converting to mm — otherwise an imperial instance would double-convert.
- No frontend changes needed — the panel already has its own fields for these settings; this only adds a native HA surface alongside it.

## Changes

- `custom_components/smart_irrigation/switch.py` (new): `SmartIrrigationSkipOnPrecipitationSwitch`.
- `custom_components/smart_irrigation/number.py`: adds `SmartIrrigationPrecipitationThresholdNumber` (hub-level), alongside the existing per-zone multiplier entity.
- `custom_components/smart_irrigation/__init__.py`: registers `"switch"` in `async_forward_entry_setups` / `async_forward_entry_unload`.
- `custom_components/smart_irrigation/translations/en.json`: adds `entity.switch.skip_on_precipitation` and `entity.number.precipitation_threshold`.
- `tests/test_switch.py`, `tests/test_number.py` (new): initial state (incl. default fallback), turn on/off / set_native_value writes, metric vs. imperial unit conversion, and refresh-on-global-config-change while ignoring per-zone dispatches.

## Test plan

- [x] `black --check custom_components/smart_irrigation/` — clean
- [x] `ruff check custom_components/smart_irrigation/` — clean
- [x] `pytest tests/ -v --cov=custom_components.smart_irrigation` — 180 passed (including the 15 new tests)
- [x] `pytest custom_components/smart_irrigation/tests/test_helpers.py custom_components/smart_irrigation/tests/test_performance.py custom_components/smart_irrigation/tests/test_diagnostics.py` (the CI "integration tests" step) — 39 passed
- [x] Confirmed pre-existing, unrelated failures in `custom_components/smart_irrigation/tests/` (not part of CI) reproduce identically on unmodified `dev`, i.e. this PR doesn't introduce any regressions there
